### PR TITLE
fjern unødvendig generering av UUID i postgres

### DIFF
--- a/src/main/kotlin/no/nav/tsm/syk_inn_api/sykmelding/persistence/SykmeldingDb.kt
+++ b/src/main/kotlin/no/nav/tsm/syk_inn_api/sykmelding/persistence/SykmeldingDb.kt
@@ -13,7 +13,7 @@ import org.hibernate.annotations.Type
 @Entity
 @Table(name = "sykmelding")
 data class SykmeldingDb(
-    @Id @GeneratedValue(strategy = GenerationType.AUTO) val id: UUID? = null,
+    @Id @GeneratedValue(strategy = GenerationType.UUID) val id: UUID? = null,
     val sykmeldingId: String,
     val mottatt: OffsetDateTime,
     val pasientIdent: String,

--- a/src/main/resources/db/migration/V1__create_sykmelding_table.sql
+++ b/src/main/resources/db/migration/V1__create_sykmelding_table.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 CREATE TABLE sykmelding
 (
-    id               UUID PRIMARY KEY     DEFAULT gen_random_uuid(),
+    id               UUID PRIMARY KEY,
     sykmelding_id    TEXT UNIQUE NOT NULL,
     mottatt          timestamptz NOT NULL,
     pasient_ident    TEXT        NOT NULL,


### PR DESCRIPTION
UUIDer genereres i postgres _og_ via hibernate. Bruk hibernate til å generere id for entiteter.

Oppdaterer v1 migration script da vi ikke er per def _prod satt_ ennå.